### PR TITLE
Fixed a bug that also connect websocket to "localhost:3000"

### DIFF
--- a/client/components/ContestRanking.tsx
+++ b/client/components/ContestRanking.tsx
@@ -88,7 +88,7 @@ function ContestRanking({ contestId, problemList }: ContestRankingProps) {
   );
 
   let [socket] = useState(function() {
-    return new WebSocket("ws://localhost:3000/ws/contest");
+    return new WebSocket(`ws://${location.host}/ws/contest`);
   });
   let [loading, setLoading] = useState(true);
 

--- a/client/hooks/useSubmissionList.ts
+++ b/client/hooks/useSubmissionList.ts
@@ -28,7 +28,7 @@ interface SubmissionListQuery extends qs.ParsedUrlQuery {
  */
 function useSubmissionList({ params, pageSize = 15 }: HookProps): HookResult {
   let [socket] = useState<WebSocket>(function() {
-    return new WebSocket("ws://localhost:3000/ws/status");
+    return new WebSocket(`ws://${location.host}/ws/status`);
   });
   let [loading, setLoading] = useState(true);
   useEffect(function() {


### PR DESCRIPTION
## Description

Currently in `useSubmissionList.ts` and `ContestRanking.tsx`, both are connected to `ws://localhost:3000/...`, which is obviously not the intended behaviour.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update